### PR TITLE
Fix bokeh dependencies

### DIFF
--- a/pbshm/pathfinder/pathfinder.py
+++ b/pbshm/pathfinder/pathfinder.py
@@ -185,7 +185,7 @@ def population_browse(population):
             fig = figure(
                 tools="pan,box_zoom,reset,save",
                 output_backend="webgl",
-                plot_height=375,
+                height=375,
                 sizing_mode="scale_width",
                 title="Population: {population} Structures: {structures} Channels: {channels}".format(
                     population=population,

--- a/pbshm/pathfinder/templates/browse.html
+++ b/pbshm/pathfinder/templates/browse.html
@@ -8,11 +8,11 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.17/js/bootstrap-select.min.js"
     integrity="sha256-QOE02Glo1C1gHzP96JOaxyIMt4XSFv/exZaYLY4dwO0=" crossorigin="anonymous">
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/2.1.0/bokeh.min.js"
-    integrity="sha256-h2bTarGzmTcV4JQHHNrA0lnReLNUUDHFSHr5QuMO418=" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/3.0.2/bokeh.min.js"
+    integrity="sha512-8aCc4Sv4kjQfm936MeLi4CFqmXKNp+WgpxPiPOr0wD4tBDnnmoWQ1bXK1hrZwTqMleXcMi88MbgwnY/Ph8/tPw==" crossorigin="anonymous">
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/2.1.0/bokeh-gl.min.js"
-    integrity="sha256-WmUe6n2oBO7BLG4XQyLid244olulV4B+CrnHgQtE6AI=" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/3.0.2/bokeh-gl.min.js"
+    integrity="sha512-/wAklz2dRT7ESalcwVsRyFQaFhMee+yA1uoSfjA9D4bUmYUGLRAoLxpWfMkbtn/Sxvk3nSidZb4U4opLhDvTYA==" crossorigin="anonymous">
 </script>
 <script>
     $(document).ready(function () {


### PR DESCRIPTION
Fix the issue with bokeh not rendering graphs within pathfinder. The problem was that the JS files for bokeh were still referencing an old version and needed to be updated. Also a depreciated attribute needed to be updated in the figure method.