### PR TITLE
Fix manifest include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-global-include *.html
-global-include *.css
+recursive-include pbshm *.html
+recursive-include pbshm *.css
 include pbshm/initialisation/*.json
 include pbshm/layout/static/*.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-core"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]


### PR DESCRIPTION
Fix the manifest file from inadvertently including HTML and CSS files from installed packages, instead of just the PBSHM namespace.