### PR TITLE
Fix user schema location

### DIFF
--- a/pbshm/initialisation/initialisation.py
+++ b/pbshm/initialisation/initialisation.py
@@ -1,6 +1,6 @@
 import json
 from os import urandom, makedirs
-from os.path import isdir, join
+from os.path import isdir, join, dirname
 
 import click
 import pymongo
@@ -53,7 +53,7 @@ def initialise_sub_system_db():
     #Create Structure Collection
     create_new_structure_collection(current_app.config["DEFAULT_COLLECTION"])
     #Load Schema File
-    with current_app.open_resource("initialisation/user-schema.json") as file:
+    with open(join(dirname(__file__), "user-schema.json"), "r") as file:
         schema = json.load(file)
     #Create User Collection
     db = db_connect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-core"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]


### PR DESCRIPTION
When deploying the application through a package, the location of the user-schema file may not always be in the path of the flask application directory. As such, the file must be loaded using a none flask method.