### PR TITLE
Removing conversion to timestamp with no timezone information

### DIFF
--- a/pbshm/timekeeper/timekeeper.py
+++ b/pbshm/timekeeper/timekeeper.py
@@ -35,6 +35,5 @@ def convert_nanoseconds(nanoseconds, unit):
     if unit == "microseconds": return str(int(nanoseconds * 0.001))
     elif unit == "milliseconds": return str(int(nanoseconds * 0.000001))
     elif unit == "seconds": return str(int(nanoseconds * 0.000000001))
-    elif unit == "datetime": return datetime.fromtimestamp(int(nanoseconds * 0.000000001)).strftime("%Y-%m-%d %H:%M:%S")
     elif unit == "datetimeutc": return datetime.fromtimestamp(int(nanoseconds * 0.000000001), timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     raise Exception("Unsupported unit")

--- a/tests/test_timekeeper.py
+++ b/tests/test_timekeeper.py
@@ -176,12 +176,6 @@ class TestConvertNanoseconds:
         """
         assert convert_nanoseconds(int(1e9), "seconds") == '1'
 
-    def test_datetime(self):
-        """
-        Test correct conversion on known nanosecond value to datetime with no timezone.
-        """
-        assert convert_nanoseconds(814309916000000000, "datetime") == "1995-10-21 22:11:56"
-
     def test_datetimeutc(self):
         """
         Test correct conversion on known nanosecond value to datetime UTC.


### PR DESCRIPTION
Removes the code relating to `unit == "datetime"` in the `convert_nanoseconds` function, as all timestamps must now have timezone information.