### PR TITLE
Flask 3 upgrade

### DIFF
--- a/pbshm/authentication/authentication.py
+++ b/pbshm/authentication/authentication.py
@@ -121,7 +121,7 @@ def login():
                 if needs_updating:
                     user_collection().update_one(
                         {"_id": user["_id"]},
-                        {"$set": {"password": generate_password_hash(password, "pbkdf2", 128)}}
+                        {"$set": {"password": generate_password_hash(password, method="scrypt:32768:8:1", salt_length=128)}}
                     )
                 session.clear()
                 session["user_id"] = str(user["_id"])

--- a/pbshm/authentication/authentication.py
+++ b/pbshm/authentication/authentication.py
@@ -98,36 +98,42 @@ def drg_check_password_hash(pwhash, password):
 def login():
     #Handle Request
     error = None
-    if(request.method == "POST"):
+    if (request.method == "POST"):
         #Validate Inputs
         email_address = request.form["email-address"]
         password = request.form["password"]
         if not email_address: error = "Missing email address."
         elif not password: error = "Missing password."
         #Process Request if no error
-        if error is None:
-            user = user_collection().find_one(
-                { "emailAddress": email_address },
-                { "_id": 1, "password": 1, "enabled": 1}
-            )
-            passwords_match, needs_updating = drg_check_password_hash(user["password"], password)
-            if user is None:
-                error = "Unable to locate these credentials."
-            elif not user["enabled"]:
-                error = "This account has been disabled."
-            elif not passwords_match:
-                error = "This email address and password do not match any credentials."
-            else:
-                if needs_updating:
-                    user_collection().update_one(
-                        {"_id": user["_id"]},
-                        {"$set": {"password": generate_password_hash(password, method="scrypt:32768:8:1", salt_length=128)}}
-                    )
-                session.clear()
-                session["user_id"] = str(user["_id"])
-                return redirect("/")
+        if error is not None:
+            return render_template("login.html", error=error)
+        
+        user = user_collection().find_one(
+            { "emailAddress": email_address },
+            { "_id": 1, "password": 1, "enabled": 1}
+        )
+        if user is None:
+            error = "Unable to locate these credentials."
+        elif not user["enabled"]:
+            error = "This account has been disabled."
+        if error is not None:
+            return render_template("login.html", error=error)
+        
+        passwords_match, needs_updating = drg_check_password_hash(user["password"], password)
+        if not passwords_match:
+            error = "This email address and password do not match any credentials."
+        else:
+            if needs_updating:
+                user_collection().update_one(
+                    {"_id": user["_id"]},
+                    {"$set": {"password": generate_password_hash(password, method="scrypt:32768:8:1", salt_length=128)}}
+                )
+            session.clear()
+            session["user_id"] = str(user["_id"])
+            return redirect("/")
     #Render Login Template
     return render_template("login.html", error=error)
+
 
 #Logout View
 @bp.route("/logout")

--- a/pbshm/authentication/authentication.py
+++ b/pbshm/authentication/authentication.py
@@ -1,14 +1,97 @@
 from functools import wraps
+import hashlib
+import hmac
 
 from bson import ObjectId
 from flask import Blueprint, g, render_template, request, session, redirect, url_for, current_app
 from werkzeug.exceptions import Unauthorized
-from werkzeug.security import check_password_hash
+from werkzeug.security import generate_password_hash
 
 from pbshm.db import user_collection
 
 #Create the Authentication Blueprint
 bp = Blueprint("authentication", __name__, template_folder="templates")
+
+DEFAULT_PBKDF2_ITERATIONS = 600000
+
+
+def _drg_hash_internal(method, salt, password):
+    """
+    A modified version of Werkzeug's '_hash_internal', extended to support 
+    SHA3_512 for legacy purposes. Taken from Werkzeug source code (version < 2.4).
+    Deprecated hash algorithms return "DEPRECATED" to signal the need for a
+    hash update, instead of the usual method and parameters.
+    """
+    method, *args = method.split(":")
+    salt_bytes = salt.encode()
+    password_bytes = password.encode()
+
+    if method == "scrypt":
+        if not args:
+            n = 2**15
+            r = 8
+            p = 1
+        else:
+            try:
+                n, r, p = map(int, args)
+            except ValueError:
+                raise ValueError("'scrypt' takes 3 arguments.") from None
+
+        maxmem = 132 * n * r * p  # ideally 128, but some extra seems needed
+        return (
+            hashlib.scrypt(
+                password_bytes, salt=salt_bytes, n=n, r=r, p=p, maxmem=maxmem
+            ).hex(),
+            f"scrypt:{n}:{r}:{p}",
+        )
+    
+    elif method == "pbkdf2":
+        len_args = len(args)
+
+        if len_args == 0:
+            hash_name = "sha256"
+            iterations = DEFAULT_PBKDF2_ITERATIONS
+        elif len_args == 1:
+            hash_name = args[0]
+            iterations = DEFAULT_PBKDF2_ITERATIONS
+        elif len_args == 2:
+            hash_name = args[0]
+            iterations = int(args[1])
+        else:
+            raise ValueError("'pbkdf2' takes 2 arguments.")
+
+        return (
+            hashlib.pbkdf2_hmac(
+                hash_name, password_bytes, salt_bytes, iterations
+            ).hex(),
+            f"pbkdf2:{hash_name}:{iterations}",
+        )
+    
+    else:
+        return (
+            hmac.new(salt_bytes, password_bytes, method).hexdigest(),
+            "DEPRECATED"
+        )
+
+
+def drg_check_password_hash(pwhash, password):
+    """
+    Verifies if the password matches the given hash (pwhash). 
+    Returns two booleans: the first indicates if the passwords match, and the 
+    second indicates if the hash requires updating.
+    """
+    method, salt, hashval = pwhash.split('$', 2)
+    hashed_pw, method = _drg_hash_internal(method, salt, password)
+    
+    passwords_match = hmac.compare_digest(hashed_pw, hashval)
+    # Even if the hash needs updating, the hash is not updated because the
+    # passwords do not match! This is an absolute fail safe as the update
+    # actually happens inside a conditional only if the passwords match, but
+    # better to be safe than sorry!
+    needs_updating = (method == "DEPRECATED") if passwords_match else False
+
+    return passwords_match, needs_updating
+
 
 #Login View
 @bp.route("/login", methods=("GET", "POST"))
@@ -27,10 +110,19 @@ def login():
                 { "emailAddress": email_address },
                 { "_id": 1, "password": 1, "enabled": 1}
             )
-            if user is None: error = "Unable to locate these credentials."
-            elif not user["enabled"]: error = "This account has been disabled."
-            elif not check_password_hash(user["password"], password): error = "This email address and password do not match any credentials."
+            passwords_match, needs_updating = drg_check_password_hash(user["password"], password)
+            if user is None:
+                error = "Unable to locate these credentials."
+            elif not user["enabled"]:
+                error = "This account has been disabled."
+            elif not passwords_match:
+                error = "This email address and password do not match any credentials."
             else:
+                if needs_updating:
+                    user_collection().update_one(
+                        {"_id": user["_id"]},
+                        {"$set": {"password": generate_password_hash(password, "pbkdf2", 128)}}
+                    )
                 session.clear()
                 session["user_id"] = str(user["_id"])
                 return redirect("/")

--- a/pbshm/initialisation/initialisation.py
+++ b/pbshm/initialisation/initialisation.py
@@ -75,7 +75,7 @@ def initialise_sub_system_new_root_user(email_address, password, first_name, sec
     db = db_connect()
     db[current_app.config["USER_COLLECTION"]].insert_one({
         "emailAddress": email_address,
-        "password": generate_password_hash(password, "sha3_512", 128),
+        "password": generate_password_hash(password, "pbkdf2", 128),
         "firstName": first_name,
         "secondName": second_name,
         "permissions": ["root"],

--- a/pbshm/initialisation/initialisation.py
+++ b/pbshm/initialisation/initialisation.py
@@ -75,7 +75,7 @@ def initialise_sub_system_new_root_user(email_address, password, first_name, sec
     db = db_connect()
     db[current_app.config["USER_COLLECTION"]].insert_one({
         "emailAddress": email_address,
-        "password": generate_password_hash(password, "pbkdf2", 128),
+        "password": generate_password_hash(password, method="scrypt:32768:8:1", salt_length=128),
         "firstName": first_name,
         "secondName": second_name,
         "permissions": ["root"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-core"
-version = "1.1.4"
+version = "1.1.5"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]
@@ -18,8 +18,8 @@ classifiers = [
 ]
 requires-python = ">=3.9.18"
 dependencies = [
-    "Flask == 2.3.2",
-    "Werkzeug == 2.3.3",
+    "Flask == 3.0.3",
+    "Werkzeug == 3.0.3",
     "pymongo == 4.3.3",
     "pytz == 2022.6"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.3.2
-Werkzeug==2.3.3
+Flask==3.0.3
+Werkzeug==3.0.3
 pymongo==4.3.3
 pytz==2022.6
 pytest==8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Flask==3.0.3
-Werkzeug==3.0.3
-pymongo==4.3.3
-pytz==2022.6
-pytest==8.1.1
+Flask==3.1.0
+Werkzeug==3.1.3
+pymongo==4.11.2
+pytz==2025.1
+pytest==8.3.5
 pytest-dependency==0.6.0
-tzdata==2024.1
+tzdata==2025.1


### PR DESCRIPTION
Adding the code required to migrate to Flask and Werkzeug 3.x.x. 
The bulk of this upgrade centred around changing the hashing method from the deprecated SHA3 algorithm.